### PR TITLE
feat: improve error handling

### DIFF
--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -1,0 +1,8 @@
+export const logger = {
+  info: (...args: unknown[]): void => {
+    console.log(...args);
+  },
+  error: (...args: unknown[]): void => {
+    console.error(...args);
+  },
+};

--- a/src/presentation/controllers/RoomControllers.ts
+++ b/src/presentation/controllers/RoomControllers.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { CreateRoomUseCase } from '../../application/usecases/CreateRoomUseCase';
 import { GetRoomUseCase } from '../../application/usecases/GetRoomUseCase';
 import { TemplateRepository } from '../../domain/repositories/TemplateRepository';
+import { logger } from '../../infrastructure/logging/logger';
 
 export class RoomController {
   constructor(
@@ -22,6 +23,7 @@ export class RoomController {
 
       res.json(result); // ← ★共通で返す
     } catch (error) {
+      logger.error('Create room error:', error);
       const message =
         error instanceof Error ? error.message : "ルーム作成中にエラーが発生しました";
       res.status(400).json({ error: message });
@@ -35,6 +37,7 @@ export class RoomController {
       const room = await this.getRoomUseCase.execute(roomId);
       res.json(room);
     } catch (error) {
+      logger.error('Get room error:', error);
       const message = error instanceof Error ? error.message : "ルーム情報の取得に失敗しました";
       const status = message.includes('存在しません') ? 404 :
         message.includes('期限切れ') ? 410 : 500;
@@ -47,6 +50,7 @@ export class RoomController {
       const templates = await this.templateRepository.findAll();
       res.json(templates);
     } catch (error) {
+      logger.error('Get templates error:', error);
       res.status(500).json({ error: "テンプレート取得に失敗しました" });
     }
   }

--- a/src/presentation/controllers/SocketController.ts
+++ b/src/presentation/controllers/SocketController.ts
@@ -3,6 +3,7 @@ import {RoomRepository} from "../../domain/repositories/RoomRepository";
 import {RoomStateRepository} from "../../domain/repositories/RoomStateRepository";
 import {UpdateCountUseCase} from "../../application/usecases/UpdateCountUseCase";
 import {RoomService} from "../../domain/services/RoomService";
+import {logger} from "../../infrastructure/logging/logger";
 
 export class SocketController {
   constructor(
@@ -21,7 +22,7 @@ export class SocketController {
     });
 
     socket.on("updateTemplate", async ({roomId, prices}) => {
-      console.log(prices);
+      logger.info("updateTemplate prices:", prices);
       const room = await this.roomRepository.findById(roomId);
       if (!room) return;
       const updatedRoom = {
@@ -66,7 +67,7 @@ export class SocketController {
         templateData: room.templateData ?? {},
       });
     } catch (error) {
-      console.error("Join error:", error);
+      logger.error("Join error:", error);
     }
   }
 
@@ -93,7 +94,7 @@ export class SocketController {
         templateId,
       });
     } catch (error) {
-      console.error("Count update error:", error);
+      logger.error("Count update error:", error);
     }
   }
 }

--- a/src/presentation/middleware/errorHandler.ts
+++ b/src/presentation/middleware/errorHandler.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from "express";
+import { logger } from "../../infrastructure/logging/logger";
+
+export function errorHandler(
+  err: unknown,
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const message = err instanceof Error ? err.message : "Internal server error";
+  logger.error("Unhandled error:", err);
+  res.status(500).json({ error: message });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,8 @@ import {Server} from "socket.io";
 import http from "http";
 import cors from "cors";
 import {db} from "./infrastructure/config/firebase";
+import {logger} from "./infrastructure/logging/logger";
+import {errorHandler} from "./presentation/middleware/errorHandler";
 
 // Repositories
 import {FirebaseRoomRepository} from "./infrastructure/database/FirebaseRoomRepository";
@@ -61,6 +63,9 @@ app.post("/api/room", (req, res) => roomController.createRoom(req, res));
 app.get("/api/room/:roomId", (req, res) => roomController.getRoom(req, res));
 app.get("/api/templates", (req, res) => roomController.getTemplates(req, res));
 
+// Error handling middleware
+app.use(errorHandler);
+
 // Socket Events
 io.on("connection", (socket) => {
   socketController.handleConnection(io, socket);
@@ -69,5 +74,13 @@ io.on("connection", (socket) => {
 // 起動
 const PORT = 3000;
 server.listen(PORT, () => {
-  console.log(`🚀 Server running at http://localhost:${PORT}`);
+  logger.info(`🚀 Server running at http://localhost:${PORT}`);
+});
+
+process.on("uncaughtException", (err) => {
+  logger.error("Uncaught exception:", err);
+});
+
+process.on("unhandledRejection", (reason) => {
+  logger.error("Unhandled rejection:", reason);
 });


### PR DESCRIPTION
## Summary
- centralize logging via a new logger utility
- add express error-handling middleware and process error listeners
- switch controllers and server to use new logger

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6892e246255c8327a1085f6aa0f021ab