### PR TITLE
Clear counts for removed plate types

### DIFF
--- a/src/presentation/controllers/SocketController.ts
+++ b/src/presentation/controllers/SocketController.ts
@@ -4,6 +4,7 @@ import {RoomStateRepository} from "../../domain/repositories/RoomStateRepository
 import {UpdateCountUseCase} from "../../application/usecases/UpdateCountUseCase";
 import {RoomService} from "../../domain/services/RoomService";
 import {logger} from "../../infrastructure/logging/logger";
+import {Member} from "../../domain/entities/Room";
 
 export class SocketController {
   constructor(
@@ -24,16 +25,47 @@ export class SocketController {
     socket.on("updateTemplate", async ({roomId, prices}) => {
       const room = await this.roomRepository.findById(roomId);
       if (!room) return;
+
+      const rawTemplate = prices ?? {};
+      const numericEntries = Object.entries(rawTemplate).filter(
+        ([, value]) => typeof value === "number"
+      );
+      const newTemplate = Object.fromEntries(numericEntries) as Record<string, number>;
+      const validColors = Object.keys(newTemplate);
+
+      const roomState = this.roomStateRepository.getRoomState(roomId);
+      let members: Member[];
+
+      if (roomState) {
+        Object.values(roomState).forEach(member => {
+          member.counts = Object.fromEntries(
+            Object.entries(member.counts).filter(([color]) =>
+              validColors.includes(color)
+            )
+          );
+        });
+        this.roomStateRepository.setRoomState(roomId, roomState);
+        members = RoomService.recordToMembers(roomState);
+      } else {
+        members = room.members.map(m => ({
+          ...m,
+          counts: Object.fromEntries(
+            Object.entries(m.counts).filter(([color]) =>
+              validColors.includes(color)
+            )
+          ),
+        }));
+      }
+
       const updatedRoom = {
         ...room,
-        templateId: room.templateId,
-        templateData: prices,
+        templateId: validColors.length > 0 ? room.templateId : "",
+        templateData: validColors.length > 0 ? newTemplate : {},
+        members,
       };
 
       await this.roomRepository.update(room.id, updatedRoom);
-      const roomState = this.roomStateRepository.getRoomState(roomId);
-      if (!roomState) return;
-      const members = RoomService.recordToMembers(roomState);
+
       io.to(roomId).emit("sync", {
         members,
         templateData: updatedRoom.templateData ?? {},


### PR DESCRIPTION
## Summary
- prune member counts to only colors present in new template data
- reset counts entirely when template data contains no plate colors
- wipe template metadata when last plate is removed to avoid stale entries

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '../../../serviceAccountKey.json')*


------
https://chatgpt.com/codex/tasks/task_e_68931c080f588327bc12cfa40b76c7b7